### PR TITLE
Fixed Player Kinematic Bug, Hard Set Boundaries for Player

### DIFF
--- a/Assets/Prefabs/Player/Player_group.prefab
+++ b/Assets/Prefabs/Player/Player_group.prefab
@@ -104,7 +104,7 @@ Rigidbody:
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 0
-  m_IsKinematic: 0
+  m_IsKinematic: 1
   m_Interpolate: 0
   m_Constraints: 4
   m_CollisionDetection: 0
@@ -116,11 +116,11 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1934570049971684927}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 4, y: 10, z: 6}
-  m_Center: {x: 0, y: 0, z: -2.79}
+  m_Size: {x: 3.7023773, y: 10, z: 6}
+  m_Center: {x: -0.14881134, y: 0, z: -2.79}
 --- !u!114 &1934570049971684916
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -164,10 +164,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bcf565fba54e7f24c8950cfa4b8c3909, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _moveSpeed: 20
-  _maximumSpeed: 0
+  _moveSpeed: 100
+  _maximumSpeed: 200
   _bankingSpeed: 40
   _desiredRotation: 23
+  _boundaries: {x: 320, y: 160}
 --- !u!114 &1934570049971684922
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -210,7 +211,7 @@ MonoBehaviour:
   _projectilePrefab: {fileID: 7752027011446696218, guid: d7d57f52abccb0248a0b29b305a8fed4,
     type: 3}
   _fireDelay: 0.2
-  _minimumFireDelay: 0.1
+  _minimumFireDelay: 0.05
   _damage: 1
   OnFire:
     m_PersistentCalls:
@@ -256,7 +257,7 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 0}
         m_MethodName: FadeOut
-        m_Mode: 1
+        m_Mode: 4
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Scripts/Gameplay/Player/PlayerHealthBehaviour.cs
+++ b/Assets/Scripts/Gameplay/Player/PlayerHealthBehaviour.cs
@@ -47,7 +47,8 @@ public class PlayerHealthBehaviour : CombatActor
     public void Kill()
     {
         Health = 0;
-        _rigidbody.useGravity = true;
+        OnDeath.Invoke();
+        gameObject.SetActive(false);
     }
     /// <summary>
     /// Hard sets the players health to be a specific float value, if the health >= maxhealth, cap it
@@ -67,5 +68,14 @@ public class PlayerHealthBehaviour : CombatActor
 
         if (actor)
             actor.TakeDamage(Damage);
+        TakeDamage(actor.Damage);
+    }
+    private void OnTriggerEnter(Collider other)
+    {
+        CombatActor actor = other.gameObject.GetComponent<CombatActor>();
+
+        if (actor)
+            actor.TakeDamage(Damage);
+        TakeDamage(actor.Damage);
     }
 }

--- a/Assets/Scripts/Gameplay/Player/PlayerMovementBehaviour.cs
+++ b/Assets/Scripts/Gameplay/Player/PlayerMovementBehaviour.cs
@@ -19,12 +19,15 @@ public class PlayerMovementBehaviour : MonoBehaviour
     [SerializeField]
     private float _desiredRotation = 45;
 
+    [Tooltip("The Boundaries That the Player can Fly (x,y)")]
+    [SerializeField]
+    private Vector2 _boundaries = new Vector2(300,160);
+
     public float MoveSpeed { get => _moveSpeed; set => _moveSpeed = Mathf.Clamp(value, 0, _maximumSpeed); }
 
     private Rigidbody _rigidbody;
     private Vector3 _velocity;
     private float _rotateThisMuch;
-    private Vector2 _screenDimensions;
 
 
     // Start is called before the first frame update
@@ -36,21 +39,21 @@ public class PlayerMovementBehaviour : MonoBehaviour
     void FixedUpdate()
     {
         //Prevent the player from moving if the velocity plus its position would put it over and instead add what would be needed
-        if (transform.position.x + _velocity.x < -Screen.safeArea.width / 16)
+        if (transform.position.x + _velocity.x < -_boundaries.x / 2)
         {
-            _velocity.x = -Screen.safeArea.width / 16 - transform.position.x;
+            _velocity.x = -_boundaries.x / 2 - transform.position.x;
         }
-        else if (transform.position.x + _velocity.x > Screen.safeArea.width / 16)
+        else if (transform.position.x + _velocity.x > _boundaries.x / 2)
         {
-            _velocity.x = Screen.safeArea.width / 16 - transform.position.x;
+            _velocity.x = _boundaries.x / 2 - transform.position.x;
         }
-        if (transform.position.z + _velocity.y < -Screen.safeArea.height / 16)
+        if (transform.position.z + _velocity.y < -_boundaries.y / 2)
         {
-            _velocity.y = -Screen.safeArea.height / 16 - transform.position.z;
+            _velocity.y = -_boundaries.y / 2 - transform.position.z;
         }
-        else if (transform.position.z + _velocity.y > Screen.safeArea.height / 16)
+        else if (transform.position.z + _velocity.y > _boundaries.y / 2)
         {
-            _velocity.y = Screen.safeArea.height / 16 - transform.position.z;
+            _velocity.y = _boundaries.y / 2 - transform.position.z;
         }
 
         //swap x and y because player does not move on y axis
@@ -95,14 +98,9 @@ public class PlayerMovementBehaviour : MonoBehaviour
         }
      }
 
-    private void Awake()
-    {
-        _screenDimensions.x = Screen.safeArea.width;
-        _screenDimensions.y = Screen.safeArea.height;
-    }
     private void OnDrawGizmos()
     {
         Gizmos.color = Color.green;
-        Gizmos.DrawWireCube(new Vector3(), new Vector3(_screenDimensions.x / 8, 0, _screenDimensions.y / 8));
+        Gizmos.DrawWireCube(new Vector3(), new Vector3(_boundaries.x, 0, _boundaries.y));
     }
 }


### PR DESCRIPTION
player kinematics changed collider to be a trigger so solution was to add an ontrigger enter; boundaries were hard set so that the player stays within the screen